### PR TITLE
Add the Netlify legal links to the footer

### DIFF
--- a/src/components/layout.astro
+++ b/src/components/layout.astro
@@ -118,6 +118,18 @@ const { title, description, home = false } = Astro.props;
       text-decoration: underline;
     }
 
+    .footer ul {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      list-style-type: none;
+    }
+
+    .footer li {
+      margin: 0 1em;
+    }
+
     .heart {
       display: inline-block;
       vertical-align: top;
@@ -131,7 +143,6 @@ const { title, description, home = false } = Astro.props;
   </style>
 </head>
 <body>
-  
   <header class="container">
     <h1 class="heading">{title}</h1>
 
@@ -147,7 +158,25 @@ const { title, description, home = false } = Astro.props;
   <slot />
 
   <footer class="footer">
-    <!-- Created with ❤️ by the Netlify team -->
+    <nav>
+      <ul>
+        <li>
+          <a class="footer-link" href="https://www.netlify.com/trust-center/">Trust Center</a>
+        </li>
+        <li>
+          <a class="footer-link" href="https://www.netlify.com/privacy/">Privacy</a>
+        </li>
+        <li>
+          <a class="footer-link" href="https://www.netlify.com/security/">Security</a>
+        </li>
+        <li>
+          <a class="footer-link" href="https://www.netlify.com/gdpr-ccpa/">GDPR/CCPA</a>
+        </li>
+        <li>
+          <a class="footer-link" href="mailto:fraud@netlify.com?subject=Abuse%20report&body=Please%20include%20the%20site%20URL%20and%20reason%20for%20your%20report%2C%20and%20we%20will%20reply%20promptly." target="_blank" rel="noopener noreferrer">Abuse</a>
+        </li>
+      </ul>
+    </nav>
   </footer>
 
 </body>


### PR DESCRIPTION
This PR closes https://github.com/netlify/docs/issues/2887 by adding the Netlify legal links to the app footer.

![CleanShot 2023-03-01 at 09 52 30@2x](https://user-images.githubusercontent.com/4294665/222208220-d31b0b68-5b0d-4a52-a1b4-7fbe40862cc7.png)

